### PR TITLE
Add onDone callback to withGoogleSecrets function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- added `onDone` callback to be called with the new next config after the secrets are loaded
+
 ## [0.2.0] - 2023-10-16
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,12 @@ type WithGoogleSecretsOptions = {
    * Determs if the application should continue on error or throw an exception (default = false)
    */
   continueOnError?: boolean;
+
+  /**
+   * The function that will be called after the secrets are loaded.
+   * The config is passed as parameter.
+   */
+  onDone?: (config: NextConfig) => void | Promise<void>;
 };
 
 type Config = {
@@ -125,7 +131,17 @@ async function iterateSecrets(
  * @returns The updated next config
  */
 const withGoogleSecrets = async (options: WithGoogleSecretsOptions) => {
-  const { projectName, filter, filterFn, mapping, versions = {}, nextConfig = {}, enabled = true, continueOnError = false } = options;
+  const {
+    projectName,
+    filter,
+    filterFn,
+    mapping,
+    versions = {},
+    nextConfig = {},
+    enabled = true,
+    continueOnError = false,
+    onDone,
+  } = options;
 
   if (!enabled) {
     return nextConfig;
@@ -154,6 +170,10 @@ const withGoogleSecrets = async (options: WithGoogleSecretsOptions) => {
         }
       }
     });
+
+    if (onDone) {
+      await onDone(newNextConfig);
+    }
   } catch (ex) {
     if (!continueOnError) {
       throw ex;


### PR DESCRIPTION
This pull request adds an `onDone` callback to the `withGoogleSecrets` function. The callback is called with the new `nextConfig` after the secrets are loaded. This allows for additional actions to be performed after the secrets are loaded.