### PR TITLE
Fix dist folder not being included in exports in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- added `dist` folder to `exports` in `package.json`
+
 ## [0.2.0] - 2023-10-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "Neolution",
   "sideEffects": false,
   "exports": {
+    "./dist/*": "./dist/*",
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
This pull request fixes the issue where the `dist` folder was not included in the `exports` section of the `package.json` file. The fix ensures that the `dist` folder is now properly included in the exports, allowing the exported files to be accessible.