### PR TITLE
Added support for `{GoogleSecret:SecretName:SecretVersion}` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+Added support for the `{GoogleSecret:SecretName:SecretVersion}` syntax. The `SecretVersion` is optional and defaults to `latest`. This allows for a more flexible way to access secrets so not all `config.{environment}.json` files need to load the same secrets.
+
 ## [0.2.1] - 2024-04-23
 
 ### Fixed

--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -1,3 +1,6 @@
-﻿export type Config = {
+﻿/**
+ * Represents the configuration object.
+ */
+export type Config = {
   [key: string]: string | Config;
 };

--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -1,0 +1,3 @@
+﻿export type Config = {
+  [key: string]: string | Config;
+};

--- a/src/types/FilterFunction.ts
+++ b/src/types/FilterFunction.ts
@@ -1,0 +1,16 @@
+﻿import { protos } from "@google-cloud/secret-manager";
+
+/**
+ * Filter function to filter secrets by name that dont have to be loaded
+ */
+export type FilterFunction = (params: {
+  /**
+   * The name of the secret (without the path)
+   */
+  name: string;
+
+  /**
+   * The secret itself
+   */
+  secret: protos.google.cloud.secretmanager.v1.ISecret;
+}) => boolean;

--- a/src/types/WithGoogleSecretsOptions.ts
+++ b/src/types/WithGoogleSecretsOptions.ts
@@ -1,0 +1,47 @@
+﻿import { NextConfig } from "next";
+import { FilterFunction } from "./FilterFunction";
+
+/**
+ * Definition of possible options for the module
+ */
+export type WithGoogleSecretsOptions = {
+  /**
+   * The project name in google could to load the secrets from
+   */
+  projectName: string;
+
+  /**
+   * A mapping to define which secret should overwritte which config entry (secretName, configEntry(ies))
+   */
+  mapping?: Record<string, string | string[]>;
+
+  /**
+   * A server side filter forwarded to the google api according to https://cloud.google.com/secret-manager/docs/filtering
+   */
+  filter?: string;
+
+  /**
+   * The filter function that gets called for every sercret before loading the value, this filter is used by the application and not by google directly, so the secrets are still loaded, just not their values.
+   */
+  filterFn?: FilterFunction;
+
+  /**
+   * The version for every secret that should be taken, default is latest
+   */
+  versions?: Record<string, string>;
+
+  /**
+   * The current next config that will be extended
+   */
+  nextConfig: NextConfig;
+
+  /**
+   * Determs if the google secrets should be loaded or not (default = true)
+   */
+  enabled?: boolean;
+
+  /**
+   * Determs if the application should continue on error or throw an exception (default = false)
+   */
+  continueOnError?: boolean;
+};

--- a/src/utils/getGoogleSecretSyntaxKeyValues.ts
+++ b/src/utils/getGoogleSecretSyntaxKeyValues.ts
@@ -1,0 +1,39 @@
+﻿import { Config } from "../types/Config";
+
+/**
+ * Retrieves the key values for Google secret syntax from the given config.
+ * @param config - The configuration object.
+ * @returns - An array of key values.
+ */
+export const getGoogleSecretSyntaxKeyValues = async (config: Config) => {
+  const keyValues: Array<{
+    secretName: string;
+    secretVersion: string;
+    path: string;
+  }> = [];
+  const regex = /{GoogleSecret:([^:}]+)(?::([^}]+))?}/g;
+  const replaceSecrets = async (config: Config, path: string) => {
+    for (const key in config) {
+      const value = config[key];
+      if (typeof value === "object") {
+        if (typeof config[key] === "object" && config[key] !== null) {
+          await replaceSecrets(config[key] as Config, `${path}__${key}`);
+        }
+      } else if (typeof value === "string") {
+        const matches = value.matchAll(regex);
+        for (const match of matches) {
+          const [, secretName, secretVersion = "latest"] = match;
+          keyValues.push({
+            secretName: secretName,
+            secretVersion: secretVersion,
+            path: `${path}__${key}`,
+          });
+        }
+      }
+    }
+  };
+  await replaceSecrets(config.serverRuntimeConfig as Config, "serverRuntimeConfig");
+  await replaceSecrets(config.publicRuntimeConfig as Config, "publicRuntimeConfig");
+
+  return keyValues;
+};

--- a/src/utils/getSecretName.ts
+++ b/src/utils/getSecretName.ts
@@ -1,0 +1,10 @@
+﻿/**
+ * Get the secret name.
+ * @param name - The name of the secret.
+ * @returns The secret name.
+ */
+export function getSecretName(name: string | undefined | null): string {
+  if (!name || !name?.length) return "";
+  const splits = name.split("/");
+  return splits[splits.length - 1];
+}

--- a/src/utils/isConfig.ts
+++ b/src/utils/isConfig.ts
@@ -1,10 +1,10 @@
 ﻿import { Config } from "../types/Config";
 
 /**
- *
- * @param config
+ * Check if the input is a valid Config object.
+ * @param config - The input to be checked.
+ * @returns True if the input is a valid Config object, false otherwise.
  */
-
 export function isConfig(config: Config | string): config is Config {
   return config !== null;
 }

--- a/src/utils/isConfig.ts
+++ b/src/utils/isConfig.ts
@@ -1,0 +1,10 @@
+﻿import { Config } from "../types/Config";
+
+/**
+ *
+ * @param config
+ */
+
+export function isConfig(config: Config | string): config is Config {
+  return config !== null;
+}

--- a/src/utils/isSecretPayload.ts
+++ b/src/utils/isSecretPayload.ts
@@ -1,0 +1,8 @@
+﻿/**
+ * Checks if the provided data is a secret payload.
+ * @param data - The data to be checked.
+ * @returns - True if the data is a Uint8Array, false otherwise.
+ */
+export function isSecretPayload(data: Uint8Array | string | null | undefined): data is Uint8Array {
+  return !!data;
+}

--- a/src/utils/iterateSecrets.ts
+++ b/src/utils/iterateSecrets.ts
@@ -1,0 +1,23 @@
+﻿import { protos } from "@google-cloud/secret-manager";
+
+/**
+ * Iterates through the secrets
+ * @param secrets The iterable secrets
+ * @param action The action that will be performed for every secret
+ */
+export async function iterateSecrets(
+  secrets: [
+    protos.google.cloud.secretmanager.v1.ISecret[],
+    protos.google.cloud.secretmanager.v1.IListSecretsRequest | null,
+    protos.google.cloud.secretmanager.v1.IListSecretsResponse,
+  ],
+  action: (secret: protos.google.cloud.secretmanager.v1.ISecret, name: string) => Promise<void>,
+) {
+  for await (const response of secrets) {
+    if (response == null || !Array.isArray(response)) continue;
+    for await (const secret of response) {
+      if (!secret || !secret.name) continue;
+      await action(secret, secret.name);
+    }
+  }
+}

--- a/src/utils/setConfigurationValue.ts
+++ b/src/utils/setConfigurationValue.ts
@@ -1,0 +1,27 @@
+﻿import { isConfig } from "./isConfig";
+import { Config } from "../types/Config";
+
+/**
+ * Set the value of a configuration property.
+ * @param config - The configuration object.
+ * @param path - The path to the property.
+ * @param value - The value to set.
+ * @param [subPath] - The sub-path within the property.
+ */
+export function setConfigurationValue(config: Config, path: string, value: string, subPath?: string): void {
+  const pathSplit = (subPath ?? path).split(/\.|__/);
+  const [currentName] = pathSplit;
+  if (pathSplit.length > 1) {
+    if (typeof config[currentName] !== "object") config[currentName] = {};
+    if (isConfig(config[currentName])) {
+      setConfigurationValue(config[currentName] as Config, path, value, pathSplit.filter((_, i) => i > 0).join("."));
+    } else {
+      console.warn("WithGoogleSecrets - couldn't override following config:", path);
+    }
+  } else if (pathSplit.length == 1) {
+    config[currentName] = value;
+    console.log("WithGoogleSecrets - overritten config with gcp secret:", path);
+  } else {
+    console.warn("WithGoogleSecrets - couldn't override following config:", path);
+  }
+}

--- a/test/WithGoogleSecrets.test.tsx
+++ b/test/WithGoogleSecrets.test.tsx
@@ -72,11 +72,35 @@ describe("WithGoogleSecrets", () => {
         testNotOverwritten2: "testNotOverwritten2",
       },
     });
+
     expect(newConfig).toStrictEqual({
       serverRuntimeConfig: {
         testOverwritten1: "test1Value",
         testOverwritten2: "test2Value",
         testOverwritten3: "test2Value",
+        testNotOverwritten1: "testNotOverwritten1",
+      },
+      testNotOverwritten2: "testNotOverwritten2",
+    });
+  });
+
+  it("load google secrets with {GoogleSecret:SecretName:Version} syntax", async () => {
+    const newConfig = await withGoogleSecrets({
+      projectName: "testProject",
+      filter: "testFilter",
+      nextConfig: {
+        serverRuntimeConfig: {
+          testOverwritten1: "{GoogleSecret:test1:testVersion}",
+          testOverwritten2: "{GoogleSecret:test2}",
+          testNotOverwritten1: "testNotOverwritten1",
+        },
+        testNotOverwritten2: "testNotOverwritten2",
+      },
+    });
+    expect(newConfig).toStrictEqual({
+      serverRuntimeConfig: {
+        testOverwritten1: "test1Value",
+        testOverwritten2: "test2Value",
         testNotOverwritten1: "testNotOverwritten1",
       },
       testNotOverwritten2: "testNotOverwritten2",


### PR DESCRIPTION
Added support for the `{GoogleSecret:SecretName:SecretVersion}` syntax. The `SecretVersion` is optional and defaults to `latest`. This allows for a more flexible way to access secrets so not all `config.{environment}.json` files need to load the same secrets.